### PR TITLE
Add fixtures for movie objects

### DIFF
--- a/frontend/src/fixtures/movieFixtures.js
+++ b/frontend/src/fixtures/movieFixtures.js
@@ -1,0 +1,38 @@
+const movieFixtures = {
+    oneMovie:
+    [
+      {
+       "id": 1,
+       "name": "Barbie",
+       "release date": "July 21, 2023",
+       "director": "Greta Gerwig"      
+      }
+    ],
+
+    threeMovies:
+    [
+        {
+            "id": 2,
+            "name": "Paddington 2",
+            "release date": "January 12, 2018",
+            "director": "Paul King"
+        },
+
+        {
+            "id": 3,
+            "name": "Top Gun: Maverick",
+            "release date": "July 21, 2023",
+            "director": "Joseph Kosinski"
+        },
+
+        {
+            "id": 4,
+            "name": "Boss Baby",
+            "release date": "March 31, 2017",
+            "director": "Tom McGrath"  
+        },
+        
+    ]
+};
+
+export { movieFixtures };


### PR DESCRIPTION
In this PR, we add fixtures for movie objects to be used in testing and storybook entries.