### PR TITLE
SL - add fixture for energydrink

### DIFF
--- a/frontend/src/fixtures/energydrinkFixtures.js
+++ b/frontend/src/fixtures/energydrinkFixtures.js
@@ -1,0 +1,38 @@
+const energydrinkFixtures = {
+    oneEnergyDrink:
+    [
+      {
+       "id": 1,
+        "name": "Celsius",
+        "caffeine content per can": "200 mg",
+        "description": "CELSIUS is a fitness drink where great taste meets function. CELSIUS is the ideal drink for anyone who wants to get the most out of their day and live fit. Backed by several clinical trials, drinking CELSIUS prior to fitness activities is proven to accelerate metabolism, burn body fat and provide essential energy."      
+      }
+    ],
+
+    threeEnergyDrinks:
+    [
+        {
+            "id": 2,
+             "name": "Monster",
+             "caffeine content per can": "160 mg",
+             "description": "Monster Energy is an energy drink that was created by Hansen Natural Company in April 2002. As of 2020, Monster Energy had a 39% share of the energy drink market, the second highest after Red Bull.",      
+        },
+
+        {
+            "id": 3,
+             "name": "Red Bull",
+             "caffeine content per can": "80 mg",
+             "description": "Red Bull is a brand of energy drinks created and owned by the Austrian company Red Bull GmbH. With a market share of 43%, it is the most popular energy drink brand as of 2020, and the third most valuable soft drink brand behind Coca-Cola and Pepsi."  
+        },
+
+        {
+            "id": 4,
+             "name": "Rockstar",
+             "caffeine content per can": "160",
+             "description": "Rockstar is an energy drink created in 2001, which, as of 2020, has a 10% market share of the global energy drink market; the third-highest after Red Bull and Monster Energy. Rockstar is based in Purchase, New York."      
+        },
+        
+    ]
+};
+
+export { energydrinkFixtures };


### PR DESCRIPTION
In this PR, we add fixtures for energy drinks to be used in testing and storybook entries.